### PR TITLE
Upgrade package easy-peasy to v6.0.5

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -31,5 +31,5 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
-            - run: npm ci --legacy-peer-deps
+            - run: npm ci
             - run: npm run build-and-package

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@vitejs/plugin-react": "^4.3.4",
                 "bestzip": "^2.2.1",
                 "classnames": "2.5.1",
-                "easy-peasy": "3.3.1",
+                "easy-peasy": "^6.0.5",
                 "handsontable": "10.0.0",
                 "jschardet": "^3.1.4",
                 "nunjucks": "3.2.4",
@@ -241,6 +241,22 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
             }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "dependencies": {
+                "regenerator-runtime": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/@babel/template": {
             "version": "7.25.9",
@@ -2109,11 +2125,6 @@
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
             "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="
         },
-        "node_modules/debounce": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-            "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
-        },
         "node_modules/debug": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -2145,41 +2156,38 @@
             }
         },
         "node_modules/easy-peasy": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-3.3.1.tgz",
-            "integrity": "sha512-c1M6xrMQyOl3JCwUdZCMcAMAuKQAxG76n2OydBTpvCPS7OSK7ZVseJL96KeCB3fpvKEvIQC8h8nShObtVPrzaA==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-6.0.5.tgz",
+            "integrity": "sha512-JRtbPp0uYVjCjG6CFr+lg7WqSHhB8p8SGBJihC2h3veP2a0EwUDYMlsSfWrYL2H7EiETVAlMbSusa5h2Tej6iQ==",
             "dependencies": {
-                "debounce": "^1.2.0",
-                "immer-peasy": "3.1.3",
-                "is-plain-object": "^3.0.0",
-                "memoizerific": "^1.11.3",
-                "prop-types": "^15.6.2",
-                "redux": "^4.0.5",
-                "redux-thunk": "^2.3.0",
-                "symbol-observable": "^1.2.0",
-                "ts-toolbelt": "^6.1.6"
+                "@babel/runtime": "^7.22.6",
+                "fast-deep-equal": "^3.1.3",
+                "immer": "^9.0.21",
+                "redux": "^4.1.2",
+                "redux-thunk": "^2.4.1",
+                "ts-toolbelt": "^9.6.0",
+                "use-sync-external-store": "^1.2.0"
             },
             "peerDependencies": {
-                "react": "^16.8.0"
-            }
-        },
-        "node_modules/easy-peasy/node_modules/is-plain-object": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-            "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-            "dependencies": {
-                "isobject": "^4.0.0"
+                "@types/react": "^16.8 || ^17.0 || ^18.0",
+                "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react-native": ">=0.59"
             },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/easy-peasy/node_modules/isobject": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-            "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-            "engines": {
-                "node": ">=0.10.0"
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
             }
         },
         "node_modules/electron-to-chromium": {
@@ -2503,10 +2511,14 @@
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
-        "node_modules/immer-peasy": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/immer-peasy/-/immer-peasy-3.1.3.tgz",
-            "integrity": "sha512-WzoZ96A93jOmcDOLNChMWAqy+ZU8vEYQx2DcKjgo7P5SToiJs+GL+5yQbWzH8X02Lhvv6xrGgVNa1xbki66Eow=="
+        "node_modules/immer": {
+            "version": "9.0.21",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+            "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -2804,19 +2816,6 @@
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
-        "node_modules/map-or-similar": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-            "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
-        },
-        "node_modules/memoizerific": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-            "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
-            "dependencies": {
-                "map-or-similar": "^1.5.0"
-            }
-        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2959,14 +2958,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3097,21 +3088,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
-        "node_modules/prop-types/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3214,18 +3190,20 @@
             }
         },
         "node_modules/redux": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-            "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "dependencies": {
-                "loose-envify": "^1.4.0",
-                "symbol-observable": "^1.2.0"
+                "@babel/runtime": "^7.9.2"
             }
         },
         "node_modules/redux-thunk": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-            "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+            "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+            "peerDependencies": {
+                "redux": "^4"
+            }
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.11",
@@ -3480,14 +3458,6 @@
             "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
             "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
         },
-        "node_modules/symbol-observable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -3525,9 +3495,9 @@
             }
         },
         "node_modules/ts-toolbelt": {
-            "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.1.13.tgz",
-            "integrity": "sha512-xfhXvHNMg9i0+L9aALC5kU+/H1eaLl5yydMe6m+2Danmfw/sIX+ixF7JTP4XSQRaG+Xd1idoTmcCVI0QmqZllQ=="
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
         },
         "node_modules/tsconfck": {
             "version": "3.0.3",
@@ -3622,6 +3592,14 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+            "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "bestzip": "^2.2.1",
         "classnames": "2.5.1",
-        "easy-peasy": "3.3.1",
+        "easy-peasy": "^6.0.5",
         "handsontable": "10.0.0",
         "jschardet": "^3.1.4",
         "nunjucks": "3.2.4",


### PR DESCRIPTION
The add-on seems to work fine with the lasted easy-peasy version.

Also removed `--legacy-peer-deps` from the workflow since the old react version dependency was removed by the upgrade.