### PR TITLE
Only parse spreadsheet on initial render and file changes

### DIFF
--- a/packages/interface/src/components/app.jsx
+++ b/packages/interface/src/components/app.jsx
@@ -23,6 +23,14 @@ export default function App() {
     const cancel = useStoreActions((actions) => actions.cancel);
     const sendEmails = useStoreActions((actions) => actions.sendEmails);
 
+    const prefs = useStoreState((state) => state.prefs);
+    const parseSpreadsheet = useStoreActions(
+        (actions) => actions.parseSpreadsheet
+    );
+    useEffect(() => {
+        parseSpreadsheet();
+    }, [prefs.fileName, parseSpreadsheet]);
+
     return (
         <>
             <header className="panel-section panel-section-header">

--- a/packages/interface/src/components/common.jsx
+++ b/packages/interface/src/components/common.jsx
@@ -6,7 +6,7 @@ import React, { useRef } from "react";
 import classNames from "classnames";
 
 function TabStrip({ children, currTab, setTab }) {
-    // make a tabstrip consisting of children with a tab spacer inbtween
+    // make a tabstrip consisting of children with a tab spacer inbetween
     // connect a click listener to each <Tab />
     let tabstrip = [];
     let tabcontents = null;

--- a/packages/interface/src/components/data-tab.jsx
+++ b/packages/interface/src/components/data-tab.jsx
@@ -20,14 +20,6 @@ function DataTab() {
         (actions) => actions.data.updateSpreadsheetHasManuallyUpdated
     );
 
-    const parseSpreadsheet = useStoreActions(
-        (actions) => actions.parseSpreadsheet
-    );
-
-    useEffect(() => {
-        parseSpreadsheet();
-    }, [prefs.fileName, parseSpreadsheet]);
-
     async function fileChanged({ name, data }) {
         name = name || "";
         data = data || [];


### PR DESCRIPTION
The TabStrip component design cause the DataTab component to unmount when switching to another tab, switching back then remounts it which triggers the useEffect in DataTab that executes parseSpreadsheet()

Moving this useEffect to app.jsx streamlines the parsing and avoids performance issues when switching to the DataTab when very large spreadsheets are loaded.

Also corrected a typo in a comment.