### PR TITLE
Fix for cursor behaviour in settings tab delay and range inputs

### DIFF
--- a/packages/interface/src/components/common.jsx
+++ b/packages/interface/src/components/common.jsx
@@ -2,7 +2,7 @@
  * Common interface components
  */
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import classNames from "classnames";
 
 function TabStrip({ children, currTab, setTab }) {
@@ -56,14 +56,26 @@ function Tab({ children, selected, onclick }) {
 
 function ClearableInput(props) {
     let { value, onChange, className, ...otherProps } = props;
+    const [localValue, setLocalValue] = useState(value);
     onChange = onChange || function() {};
     const inputRef = useRef();
 
     function clearClicked() {
+        setLocalValue("")
         onChange("");
         inputRef.current.focus();
     }
     function inputChangeEvent(e) {
+        // Only allow numbers, hyphen, comma and period
+        const re = /^[\d-,.]+$/;
+
+        // Update local state if value is blank or matches the regex
+        if (e.target.value === '' || re.test(e.target.value)) {
+           setLocalValue(e.target.value);
+        }
+    }
+    // Update global state when input loses focus
+    function inputBlurEvent(e) {
         onChange(e.target.value);
     }
 
@@ -72,12 +84,13 @@ function ClearableInput(props) {
             <input
                 className={className + " form-control"}
                 type="text"
-                value={value}
+                value={localValue}
                 onChange={inputChangeEvent}
+                onBlur={inputBlurEvent}
                 ref={inputRef}
                 {...otherProps}
             />
-            {value && (
+            {localValue && (
                 <span className="form-control-feedback" onClick={clearClicked}>
                     <i className="fas fa-times-circle" />
                 </span>

--- a/packages/interface/src/components/common.jsx
+++ b/packages/interface/src/components/common.jsx
@@ -56,37 +56,32 @@ function Tab({ children, selected, onclick }) {
 
 function ClearableInput(props) {
     let { value, onChange, className, ...otherProps } = props;
-    const [localValue, setLocalValue] = useState(value);
     onChange = onChange || function() {};
     const inputRef = useRef();
+
+    // Use local state to avoid cursor jumping to end of input on changes
+    const [localValue, setLocalValue] = useState(value);
 
     function clearClicked() {
         setLocalValue("")
         onChange("");
         inputRef.current.focus();
     }
-    function inputChangeEvent(e) {
-        // Only allow numbers, hyphen, comma and period
-        const re = /^[\d-,.]+$/;
 
-        // Update local state if value is blank or matches the regex
-        if (e.target.value === '' || re.test(e.target.value)) {
-           setLocalValue(e.target.value);
-        }
+    function onChangeLocal(e) {
+        const value = e.target ? e.target.value : e;
+        setLocalValue(value);
     }
-    // Update global state when input loses focus
-    function inputBlurEvent(e) {
-        onChange(e.target.value);
-    }
-
+    
     return (
         <div className="browser-style form-group">
             <input
                 className={className + " form-control"}
                 type="text"
                 value={localValue}
-                onChange={inputChangeEvent}
-                onBlur={inputBlurEvent}
+                onChange={onChangeLocal}
+                // Update global state when input loses focus
+                onBlur={onChange}
                 ref={inputRef}
                 {...otherProps}
             />

--- a/packages/interface/src/components/settings-tab.jsx
+++ b/packages/interface/src/components/settings-tab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import classNames from "classnames";
 import { ClearableInput } from "./common";
@@ -17,6 +17,14 @@ function SettingsTab() {
             }
         };
     }
+
+    // Use local state for delay value to avoid cursor jumping to end of input on changes
+    const [delayValue, setDelayValue] = useState(prefs.delay);
+    function onChangeDelayInput(e) {
+        const value = e.target ? e.target.value : e;
+        setDelayValue(value);
+    }
+
     // a range is invalid if it is non-empty and parseRange parses it
     // to an empty array
     const rangeValid =
@@ -48,8 +56,10 @@ function SettingsTab() {
             <input
                 id="pref-delay"
                 type="number"
-                value={prefs.delay}
-                onChange={generatePrefUpdate("delay")}
+                value={delayValue}
+                onChange={onChangeDelayInput}
+                // Update global state when delay input loses focus
+                onBlur={generatePrefUpdate("delay")}
                 className="browser-style settings-input"
                 title={strings.messageDelayDesc}
             />


### PR DESCRIPTION
When editing the value in the input boxes the components would unmount and remount causing the cursor to jump to the rightmost position on every change.