### PR TITLE
Fixes for issues when opening the same file

### DIFF
--- a/packages/interface/src/components/common.jsx
+++ b/packages/interface/src/components/common.jsx
@@ -130,6 +130,9 @@ function ClearableFileInput(props) {
         //setFilename(file.name);
         let dat = await readFile(file);
         dat = new Uint8Array(dat);
+        // Opening the same file, e.g. after modifying its content, will not trigger
+        // useEffect with parseSpreadsheet unless there is a state change
+        onChange({ name: "", data: [] });
         onChange({ name: file.name, data: dat });
     }
     function clearClicked() {
@@ -160,6 +163,8 @@ function ClearableFileInput(props) {
                 id={id}
                 ref={fileRef}
                 onChange={fileChanged}
+                // Needed to trigger onChange when opening the same file
+                onClick={(e) => e.target.value = null}
             />
             <span
                 className="form-control-feedback-prefix"

--- a/packages/interface/src/components/common.jsx
+++ b/packages/interface/src/components/common.jsx
@@ -112,7 +112,6 @@ function ClearableFileInput(props) {
     // will attach to it instead of the display input
     let { accept, onChange, className, id, filename, ...otherProps } = props;
     onChange = onChange || function() {};
-    //const [filename, setFilename] = useState("")
     const inputRef = useRef();
     const fileRef = useRef();
 
@@ -127,7 +126,6 @@ function ClearableFileInput(props) {
         if (!file) {
             return;
         }
-        //setFilename(file.name);
         let dat = await readFile(file);
         dat = new Uint8Array(dat);
         // Opening the same file, e.g. after modifying its content, will not trigger
@@ -136,7 +134,6 @@ function ClearableFileInput(props) {
         onChange({ name: file.name, data: dat });
     }
     function clearClicked() {
-        //setFilename("");
         onChange({ name: null, data: null });
         inputRef.current.focus();
     }


### PR DESCRIPTION
The file `input` in the `ClearableFileInput` component did not work if opening the same file multiple times. For example  to fresh the data after editing the source file.

This is due to `input` elements not triggering `onChange` in these cases.
Solution referenced [here](https://stackoverflow.com/a/58527761/12019249)

Also added a state change for `prefs.fileName` so that the `useEffect` with `parseSpreadsheet()` in app.jsx would trigger and thus refresh the HotTable when the same file as in the current state is opened.

It would also be helpful to be able to refresh the data from the source file after closing and reopening the add-on, but this seems to be prevented by browser security not allowing reading local files unless the user selects one (which is an important security feature).

Lastly I cleaned up commented code  in the `ClearableFileInput` component that seems to be obsolete.