### PR TITLE
Update package-lock.json after version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mailmergep",
-    "version": "2.6.2",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mailmergep",
-            "version": "2.6.2",
+            "version": "2.7.0",
             "workspaces": [
                 "packages/iframe-service",
                 "packages/interface",


### PR DESCRIPTION
After running `npm install` there were changes to package-lock.json after the last version bump.