### PR TITLE
Add Vite tsconfig and refactor parseRange

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,10 @@
                 "vite-plugin-svgr": "^4.3.0",
                 "vite-tsconfig-paths": "^5.1.4",
                 "xlsx": "file:vendor/xlsx-0.20.3.tgz"
+            },
+            "devDependencies": {
+                "@types/node": "^22.13.4",
+                "vitest": "^3.0.5"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1506,6 +1510,16 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
         },
+        "node_modules/@types/node": {
+            "version": "22.13.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+            "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
+        },
         "node_modules/@types/trusted-types": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -1528,6 +1542,129 @@
             },
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
+            "integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.0.5",
+                "@vitest/utils": "3.0.5",
+                "chai": "^5.1.2",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.5.tgz",
+            "integrity": "sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.0.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
+            "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.5.tgz",
+            "integrity": "sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.0.5",
+                "pathe": "^2.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.5.tgz",
+            "integrity": "sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.0.5",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.5.tgz",
+            "integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.5.tgz",
+            "integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.0.5",
+                "loupe": "^3.1.2",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@volar/language-core": {
@@ -1779,6 +1916,16 @@
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/async": {
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -1920,6 +2067,16 @@
                 "node": "*"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1957,6 +2114,33 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ]
+        },
+        "node_modules/chai": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            }
         },
         "node_modules/chevrotain": {
             "version": "6.5.0",
@@ -2116,6 +2300,16 @@
                 }
             }
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/dompurify": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
@@ -2200,6 +2394,13 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esbuild": {
             "version": "0.24.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
@@ -2251,6 +2452,16 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        },
+        "node_modules/expect-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+            "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2750,6 +2961,13 @@
                 "loose-envify": "cli.js"
             }
         },
+        "node_modules/loupe": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lower-case": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -2982,6 +3200,16 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
             "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w=="
+        },
+        "node_modules/pathval": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -3296,6 +3524,13 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/snake-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -3325,6 +3560,20 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+            "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -3419,6 +3668,50 @@
             "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
             "optional": true
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinypool": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+            "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3475,6 +3768,13 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
             "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "2.0.0",
@@ -3604,6 +3904,29 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.5.tgz",
+            "integrity": "sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.0",
+                "es-module-lexer": "^1.6.0",
+                "pathe": "^2.0.2",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/vite-plugin-dts": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.0.tgz",
@@ -3705,6 +4028,76 @@
                 }
             }
         },
+        "node_modules/vitest": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.5.tgz",
+            "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "3.0.5",
+                "@vitest/mocker": "3.0.5",
+                "@vitest/pretty-format": "^3.0.5",
+                "@vitest/runner": "3.0.5",
+                "@vitest/snapshot": "3.0.5",
+                "@vitest/spy": "3.0.5",
+                "@vitest/utils": "3.0.5",
+                "chai": "^5.1.2",
+                "debug": "^4.4.0",
+                "expect-type": "^1.1.0",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.2",
+                "std-env": "^3.8.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinypool": "^1.0.2",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0",
+                "vite-node": "3.0.5",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.0.5",
+                "@vitest/ui": "3.0.5",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
@@ -3722,6 +4115,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     },
     "browserslist": [
         "firefox >= 91"
-    ]
+    ],
+    "devDependencies": {
+        "@types/node": "^22.13.4",
+        "vitest": "^3.0.5"
+    }
 }

--- a/packages/interface/src/components/preview-tab.jsx
+++ b/packages/interface/src/components/preview-tab.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useStoreState, useStoreActions } from "easy-peasy";
-import { parseRange } from "../utils.js";
+import { parseRange } from "../utils/parseRange";
 
 import LocalizedStrings from "react-localization";
 const formatString = LocalizedStrings.prototype.formatString;

--- a/packages/interface/src/components/settings-tab.jsx
+++ b/packages/interface/src/components/settings-tab.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import classNames from "classnames";
 import { ClearableInput } from "./common";
-import { parseRange } from "../utils";
+import { parseRange } from "../utils/parseRange";
 
 function SettingsTab() {
     const prefs = useStoreState((state) => state.prefs);

--- a/packages/interface/src/utils.js
+++ b/packages/interface/src/utils.js
@@ -339,68 +339,6 @@ function fillTemplateLegacy(template, subsArray) {
     return ret;
 }
 
-/*
- * Parse a string range. Return an array containing
- * all parsed values. E.g. "3,4,6-9" will return [3,4,6,7,8,9].
- *
- * An incomplete range will assume `minVal` and `maxVal` are to
- * be used. E.g., "3-" == "3-<maxVal>".
- *
- * Based off of https://github.com/euank/node-parse-numeric-range
- */
-function parseRange(str, minVal = 0, maxVal = 100) {
-    function parsePart(str) {
-        // just a number
-        if (/^-?\d+$/.test(str)) {
-            return parseInt(str, 10);
-        }
-        var m;
-        // 1-5 or 1..5 (equivilant) or 1...5 (doesn't include 5)
-        if (
-            (m = str.match(/^(-?\d*)(-|\.\.\.?|\u2025|\u2026|\u22EF)(-?\d*)$/))
-        ) {
-            var lhs = m[1] || minVal;
-            var sep = m[2];
-            var rhs = m[3] || maxVal;
-            if (lhs && rhs) {
-                lhs = parseInt(lhs);
-                rhs = parseInt(rhs);
-                var res = [];
-                var incr = lhs < rhs ? 1 : -1;
-
-                // Make it inclusive by moving the right 'stop-point' away by one.
-                if (sep === "-" || sep === ".." || sep === "\u2025") {
-                    rhs += incr;
-                }
-
-                for (var i = lhs; i !== rhs; i += incr) {
-                    res.push(i);
-                }
-                return res;
-            }
-        }
-        return [];
-    }
-    var parts = str.split(",");
-
-    var toFlatten = parts.map(function (el) {
-        return parsePart(el.trim());
-    });
-
-    // reduce can't handle single element arrays
-    if (toFlatten.length === 0) return [];
-    if (toFlatten.length === 1) {
-        if (Array.isArray(toFlatten[0])) return toFlatten[0];
-        return toFlatten;
-    }
-
-    return toFlatten.reduce(function (lhs, rhs) {
-        if (!Array.isArray(lhs)) lhs = [lhs];
-        if (!Array.isArray(rhs)) rhs = [rhs];
-        return lhs.concat(rhs);
-    });
-}
-
 /**
  * Returns a promise that delays for number of milliseconds
  *
@@ -441,4 +379,4 @@ function formatTime(time) {
     return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
 }
 
-export { fillTemplate, parseSpreadsheet, parseRange, delay, formatTime };
+export { fillTemplate, parseSpreadsheet, delay, formatTime };

--- a/packages/interface/src/utils/parseRange.test.ts
+++ b/packages/interface/src/utils/parseRange.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Original tests from https://github.com/euank/node-parse-numeric-range
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseRange } from './parseRange';
+
+function peq(x: string, y: number[]) {
+    expect(parseRange(x)).to.eql(y);
+}
+
+describe('parseRange', function () {
+    it('should parse 1', function () {
+        peq('1', [1]);
+    });
+    it('should parse 1,1', function () {
+        peq('1,1', [1, 1]);
+    });
+    it('should parse 1-5', function () {
+        peq('1-5', [1, 2, 3, 4, 5]);
+    });
+    it('should parse 5-1', function () {
+        peq('5-1', [5, 4, 3, 2, 1]);
+    });
+    it('should parse 1-3,5-6', function () {
+        peq('1-3,5-6', [1, 2, 3, 5, 6]);
+    });
+    it('should parse 10..15', function () {
+        peq('10..15', [10, 11, 12, 13, 14, 15]);
+    });
+    it('should parse 10...15', function () {
+        peq('10...15', [10, 11, 12, 13, 14]);
+    });
+    it('should parse 10..12,13...15,2,8', function () {
+        peq('10..12,13...15,2,8', [10, 11, 12, 13, 14, 2, 8]);
+    });
+    it('should parse ""', function () {
+        peq('', []);
+    });
+    it('should parse -5', function () {
+        peq('-5', [-5]);
+    });
+    it('should parse -5--10', function () {
+        peq('-5--10', [-5, -6, -7, -8, -9, -10]);
+    });
+    it('should parse -1..2,-1...2', function () {
+        peq('-1..2,-1...2', [-1, 0, 1, 2, -1, 0, 1]);
+    });
+    it('should parse 1‥3', function () {
+        peq('1‥3', [1, 2, 3]);
+    });
+    it('should parse 1⋯3', function () {
+        peq('1⋯3', [1, 2]);
+    });
+    it('should parse 1…3', function () {
+        peq('1…3', [1, 2]);
+    });
+    it('should parse ranges with a space in between', function () {
+        peq('1-2, 3-4', [1, 2, 3, 4]);
+    });
+});

--- a/packages/interface/src/utils/parseRange.test.ts
+++ b/packages/interface/src/utils/parseRange.test.ts
@@ -1,7 +1,3 @@
-/**
- * Original tests from https://github.com/euank/node-parse-numeric-range
- */
-
 import { describe, expect, it } from 'vitest';
 import { parseRange } from './parseRange';
 
@@ -25,37 +21,22 @@ describe('parseRange', function () {
     it('should parse 1-3,5-6', function () {
         peq('1-3,5-6', [1, 2, 3, 5, 6]);
     });
-    it('should parse 10..15', function () {
-        peq('10..15', [10, 11, 12, 13, 14, 15]);
-    });
-    it('should parse 10...15', function () {
-        peq('10...15', [10, 11, 12, 13, 14]);
-    });
-    it('should parse 10..12,13...15,2,8', function () {
-        peq('10..12,13...15,2,8', [10, 11, 12, 13, 14, 2, 8]);
-    });
     it('should parse ""', function () {
         peq('', []);
     });
-    it('should parse -5', function () {
-        peq('-5', [-5]);
-    });
-    it('should parse -5--10', function () {
-        peq('-5--10', [-5, -6, -7, -8, -9, -10]);
-    });
-    it('should parse -1..2,-1...2', function () {
-        peq('-1..2,-1...2', [-1, 0, 1, 2, -1, 0, 1]);
-    });
-    it('should parse 1‥3', function () {
-        peq('1‥3', [1, 2, 3]);
-    });
-    it('should parse 1⋯3', function () {
-        peq('1⋯3', [1, 2]);
-    });
-    it('should parse 1…3', function () {
-        peq('1…3', [1, 2]);
-    });
     it('should parse ranges with a space in between', function () {
         peq('1-2, 3-4', [1, 2, 3, 4]);
+    });
+    it('should parse mixed ranges and integers', function () {
+        peq('1-2, 5, 3-4, 8', [1, 2, 5, 3, 4, 8]);
+    });
+    it('should parse mixed integers and ranges', function () {
+        peq('1, 2-5, 4-8, 3', [1, 2, 3, 4, 5, 4, 5, 6, 7, 8, 3]);
+    });
+    it('should parse ranges without start specified', function () {
+        peq('-5', [1, 2, 3, 4, 5]);
+    });
+    it('should parse ranges without end specified', function () {
+        peq('95-', [95, 96, 97, 98, 99, 100]);
     });
 });

--- a/packages/interface/src/utils/parseRange.ts
+++ b/packages/interface/src/utils/parseRange.ts
@@ -1,0 +1,49 @@
+/*
+ * Parse a string range. Return an array containing
+ * all parsed values. E.g. "3,4,6-9" will return [3,4,6,7,8,9].
+ *
+ * An incomplete range will assume `minVal` and `maxVal` are to
+ * be used. E.g., "3-" == "3-<maxVal>".
+ *
+ * Based off of https://github.com/euank/node-parse-numeric-range
+ */
+export function parseRange(range: string, minVal = 0, maxVal = 100): number[] {
+    function parsePart(part: string) {
+        // just a number
+        if (/^-?\d+$/.test(part)) {
+            return [parseInt(part, 10)];
+        }
+        let m: RegExpMatchArray | null;
+        // 1-5 or 1..5 (equivilant) or 1...5 (doesn't include 5)
+        if (
+            (m = part.match(/^(-?\d*)(-|\.\.\.?|\u2025|\u2026|\u22EF)(-?\d*)$/))
+        ) {
+            const lhs = parseInt(m[1]) || minVal;
+            const sep = m[2];
+            let rhs = parseInt(m[3]) || maxVal;
+            if (lhs && rhs) {
+                const res = [];
+                const incr = lhs < rhs ? 1 : -1;
+
+                // Make it inclusive by moving the right 'stop-point' away by one.
+                if (sep === "-" || sep === ".." || sep === "\u2025") {
+                    rhs += incr;
+                }
+
+                for (let i = lhs; i !== rhs; i += incr) {
+                    res.push(i);
+                }
+                return res;
+            }
+        }
+        return [];
+    }
+    const parts = range.split(",");
+
+    const parsedRange = parts.reduce<number[]>(
+        (acc, cur) => [...acc, ...parsePart(cur.trim())],
+        []
+    );
+
+    return parsedRange;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+
+        /* Bundler mode */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "isolatedModules": true,
+        "moduleDetection": "force",
+        "noEmit": true,
+        "jsx": "react-jsx",
+
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedSideEffectImports": true
+    },
+    "include": ["packages"]
+}


### PR DESCRIPTION
I've done most of the conversion to TS for `packages/interface`, but thought it's best to split it up into several PR's as it's not all done and it's too much for one PR anyway. And some of the changes I would prefer to get confimed as ok before continuing with the next.

This PR contains the basic TS config for Vite which I copied from a fresh Vite react typescript project running `npm create vite@latest clean-vite-react-ts -- --react-ts`, just with the `include` updated. It has worked great this far. 

The other change is a refactoring of parseRange which had a quite broad return type of `number | (number | number[])[]` while it actually only seems and needs to return `number[]`. The return value is only used as a one dimensional number array by `renderEmails` in model.js as well as in settings-tab.jsx and preview-tab.jsx.

To unit test `parseRange` I had to move it into a separate file (I also installed vitest as a dev dependency)
I copied the original test file from https://github.com/euank/node-parse-numeric-range and parseRange seems to behave like before the refactoring.